### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the `releaseBranch:` block to `enonic-gradle.yml` so that pushes to either `master` or `2.x` are recognized as release branches by `enonic/release-tools/build-and-publish`.

This sets up `2.x` as the maintenance branch tracking the XP 7 lineage (current `xpVersion=7.0.0`, `version=2.1.2-SNAPSHOT`). XP 8 upgrade lands on `master` separately.

Mirrors the structure used on `enonic/app-booster` (`master` + `1.x`).