### PR TITLE
Upgrade to XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -1,0 +1,19 @@
+name: Generate Documentation
+
+on:
+  push:
+    branches:
+      - "master"
+      - "2.x"
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: enonic/release-tools/generate-docs@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          webhook-secret: ${{ secrets.DEVELOPER_PORTAL_WEBHOOK_SECRET }}

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.enonic.defaults' version '2.1.6'
-    id 'com.enonic.xp.base' version '3.6.2'
+    id 'com.enonic.xp.base'
 }
 
 dependencies {
-    implementation "com.enonic.xp:lib-portal:${xpVersion}"
-    implementation "com.enonic.lib:lib-mustache:2.1.1"
+    implementation xplibs.portal
+    implementation 'com.enonic.lib:lib-mustache:2.1.1'
 }
 
 repositories {

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "2.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 #
 group = com.enonic.lib
 projectName = lib-idproviderdisplay
-xpVersion = 7.0.0
-version=2.1.2-SNAPSHOT
+xpVersion = 8.0.0-B4
+version=3.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName


### PR DESCRIPTION
Upgrades `lib-idproviderdisplay` from XP 7 to XP 8 (`8.0.0-B4`) following the `xp-app-upgrader` skill (library subset).

## Build / dependency changes

- `gradle.properties`: `xpVersion=7.0.0` → `8.0.0-B4`, `version=2.1.2-SNAPSHOT` → `3.0.0-SNAPSHOT`
- `settings.gradle`: add `id 'com.enonic.xp.settings' version '4.0.0-B1'` (latest non-SNAPSHOT published to plugins.gradle.org)
- `build.gradle`:
  - drop the `version '3.6.2'` pin on `com.enonic.xp.base` (settings plugin supplies it)
  - replace `com.enonic.xp:lib-portal:${xpVersion}` with the catalog alias `xplibs.portal`
  - third-party `com.enonic.lib:lib-mustache:2.1.1` retains long-form coordinates per the skill
- Gradle wrapper: 8.0.2 → 9.4.1
- `com.enonic.defaults 2.1.6` retained — `LICENSE.txt` already exists at the repo root, so the new Gradle 9 license-file enforcement is satisfied.

No Java sources or tests in this lib (just JS + assets), so no JUnit migration, toolchain, or `junit-platform-launcher` changes are needed. JS code uses `lib/xp/portal` and `lib/mustache` which are unchanged in XP 8.

`xp8migrator` was **skipped** — library has no app/site/widget descriptors.

## Workflow + docgen changes

- `.github/workflows/enonic-gradle.yml`: add `releaseBranch: |\n  master\n  2.x` to the `build-and-publish` step (mirroring `enonic/app-booster`).
- `.github/workflows/enonic-docgen.yml`: new workflow gating on `master` and `2.x` (per `Has docgen: true`).
- `docs/versions.json`: new file pointing `stable` → `2.x`, `next` → `master`.

## Maintenance branch

The `2.x` branch was created from old `master` HEAD `35fb1ccb` to capture the XP 7 lineage. PR #37 lands the matching `releaseBranch:` config there. Both branches reference the same release-tools target, so a release cut from either one is recognized.

## Verification

- `./gradlew clean build` ✅ green on Java 25 with the 9.4.1 wrapper
- `./gradlew test` ✅ no test sources but task succeeds

Runtime/deploy verification not required (sandbox is ephemeral).